### PR TITLE
Add network interceptor to log capture

### DIFF
--- a/src/utils/log-capture.test.ts
+++ b/src/utils/log-capture.test.ts
@@ -171,4 +171,220 @@ describe('log-capture', () => {
       expect(logs[0]!.message).toContain('[OPENAI_KEY_REDACTED]');
     });
   });
+
+  describe('network interceptor', () => {
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      restoreConsole();
+      clearCapturedLogs();
+      globalThis.fetch = originalFetch;
+    });
+
+    it('captures successful fetch requests', async () => {
+      const mockResponse = new Response(JSON.stringify({ data: 'test' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/data');
+
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]!.level).toBe('info');
+      expect(logs[0]!.message).toContain('[NETWORK]');
+      expect(logs[0]!.message).toContain('GET https://api.example.com/data');
+      expect(logs[0]!.message).toContain('Status: 200');
+    });
+
+    it('captures POST requests with body', async () => {
+      const mockResponse = new Response(JSON.stringify({ success: true }), {
+        status: 201,
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/users', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'John' }),
+      });
+
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]!.message).toContain('POST https://api.example.com/users');
+      expect(logs[0]!.message).toContain('Request Body:');
+      expect(logs[0]!.message).toContain('John');
+    });
+
+    it('logs error status codes as errors', async () => {
+      const mockResponse = new Response('Not Found', {
+        status: 404,
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/missing');
+
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]!.level).toBe('error');
+      expect(logs[0]!.message).toContain('Status: 404');
+    });
+
+    it('logs 500 errors as error level', async () => {
+      const mockResponse = new Response('Server Error', {
+        status: 500,
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/error');
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.level).toBe('error');
+      expect(logs[0]!.message).toContain('Status: 500');
+    });
+
+    it('captures network errors', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network failure'));
+
+      initLogCapture();
+
+      await expect(fetch('https://api.example.com/fail')).rejects.toThrow(
+        'Network failure'
+      );
+
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]!.level).toBe('error');
+      expect(logs[0]!.message).toContain('[Network Error: Network failure]');
+    });
+
+    it('masks sensitive data in request bodies', async () => {
+      const mockResponse = new Response('OK', { status: 200 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture({ maskSensitiveData: true });
+
+      await fetch('https://api.example.com/auth', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'secret@example.com', apiKey: 'sk-12345678901234567890' }),
+      });
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toContain('[EMAIL_REDACTED]');
+      expect(logs[0]!.message).toContain('[OPENAI_KEY_REDACTED]');
+      expect(logs[0]!.message).not.toContain('secret@example.com');
+    });
+
+    it('masks sensitive data in response bodies', async () => {
+      const mockResponse = new Response(
+        JSON.stringify({ user: { email: 'private@example.com' } }),
+        { status: 200 }
+      );
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture({ maskSensitiveData: true });
+
+      await fetch('https://api.example.com/user');
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toContain('[EMAIL_REDACTED]');
+      expect(logs[0]!.message).not.toContain('private@example.com');
+    });
+
+    it('truncates long response bodies', async () => {
+      const longBody = 'x'.repeat(2000);
+      const mockResponse = new Response(longBody, { status: 200 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/large');
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toContain('[TRUNCATED]');
+      expect(logs[0]!.message.length).toBeLessThan(longBody.length + 500);
+    });
+
+    it('handles Request objects', async () => {
+      const mockResponse = new Response('OK', { status: 200 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      const request = new Request('https://api.example.com/resource', {
+        method: 'PUT',
+      });
+      await fetch(request);
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toContain('PUT https://api.example.com/resource');
+    });
+
+    it('handles URL objects', async () => {
+      const mockResponse = new Response('OK', { status: 200 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch(new URL('https://api.example.com/url-object'));
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toContain('GET https://api.example.com/url-object');
+    });
+
+    it('captures duration in milliseconds', async () => {
+      const mockResponse = new Response('OK', { status: 200 });
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      initLogCapture();
+
+      await fetch('https://api.example.com/timed');
+
+      const logs = getCapturedLogs();
+      expect(logs[0]!.message).toMatch(/Duration: \d+ms/);
+    });
+
+    it('restores original fetch on restoreConsole', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response('OK'));
+      globalThis.fetch = mockFetch;
+
+      initLogCapture();
+      restoreConsole();
+
+      // After restore, fetch should work but not capture logs
+      clearCapturedLogs();
+      await fetch('https://api.example.com/test');
+
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(0);
+    });
+
+    it('does not break app when fetch fails', async () => {
+      const networkError = new Error('Connection refused');
+      globalThis.fetch = vi.fn().mockRejectedValue(networkError);
+
+      initLogCapture();
+
+      // Should throw the original error
+      await expect(fetch('https://api.example.com/fail')).rejects.toThrow(
+        'Connection refused'
+      );
+
+      // But still capture the log
+      const logs = getCapturedLogs();
+      expect(logs).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Implement "Black Box Recorder" feature that monkey-patches window.fetch to capture all network requests/responses automatically. This helps debug logical errors that don't produce console errors.

- Capture method, URL, request body (if JSON string)
- Capture response status and body (truncated to 1000 chars)
- Use response.clone() to safely read body without consuming stream
- Apply maskSensitiveData to all captured request/response bodies
- Prefix network logs with [NETWORK] for clear distinction
- Log 4xx/5xx status codes as 'error' level
- Gracefully handle network failures without breaking the app
- Restore original fetch on restoreConsole()